### PR TITLE
Mask only secrets

### DIFF
--- a/src/process.ts
+++ b/src/process.ts
@@ -65,7 +65,10 @@ const processParameterPairChunk = async (
                 continue;
             }
 
-            setSecret(value);
+            if (withDecryption) {
+                setSecret(value);
+            }
+
             exportVariable(parameterPairs[name], value);
             info(
                 `Env variable ${parameterPairs[name]} set with value from ssm parameterName ${name}`


### PR DESCRIPTION
The user has a possibility to decide if a variable should be masked.
If the user doesn't want to decrypt secret variable, then what's the point to mask encrypted value?

The problem is described here https://github.com/dkershner6/aws-ssm-getparameters-action/issues/42