### PR TITLE
changed node version from 12 to 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
         default: 'true'
 
 runs:
-    using: 'node12'
+    using: 'node16'
     main: 'dist/index.js'
 branding:
     icon: 'lock'


### PR DESCRIPTION
Changed Node version from 12 to 16.

Reason is this blogpost by github -->https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

